### PR TITLE
Correct/update OpenSky state attribute, was "heading" now "true_track"

### DIFF
--- a/collectData.py
+++ b/collectData.py
@@ -66,7 +66,7 @@ while True:
             longitude.append(s.longitude)
             geoaltitude.append(s.geo_altitude)
             altitude.append(s.baro_altitude)
-            track.append(s.heading)
+            track.append(s.true_track)
             icao24.append(s.icao24)
             groundspeed.append(s.velocity)
             vertical_rate.append(s.vertical_rate)


### PR DESCRIPTION
opensky-api (the REST API and maybe the java one too?) was changed around 2018 / v1.3.0 such that "heading" attribute of state vectors was renamed to "true_track". It looks like the python API (which this repo uses) followed suit around 2022.