### PR TITLE
Update date format in error message returned for no data in states

### DIFF
--- a/collectData.py
+++ b/collectData.py
@@ -95,7 +95,7 @@ while True:
         minute = timeinfo.tm_min
         sec = timeinfo.tm_sec
 
-        print("Error collecting data for {}/{}/{}/{}:{}".format(year,month,day,hr,minute,sec))
+        print("Error collecting data for {}/{}/{} {}:{}:{}".format(year,month,day,hr,minute,sec))
         end = time.time()
 
         if not abs(end-start) > 5:


### PR DESCRIPTION
Previously, datetime in error message appeared like this:

> Error collecting data for 2024/3/6/1:29
> Error collecting data for 2024/3/6/1:30
> Error collecting data for 2024/3/6/1:30
> Error collecting data for 2024/3/6/1:30
> Error collecting data for 2024/3/6/1:30
> Error collecting data for 2024/3/6/1:30

Now it should be formatted like the output from this example:

```
Python 3.12.2 (main, Feb 13 2024, 09:28:52) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import time
>>>
>>> timeinfo = time.gmtime()
>>>
>>> day = timeinfo.tm_mday
>>> month = timeinfo.tm_mon
>>> year = timeinfo.tm_year
>>> hr = timeinfo.tm_hour
>>> minute = timeinfo.tm_min
>>> sec = timeinfo.tm_sec
>>>
>>> print("Error collecting data for {}/{}/{} {}:{}:{}".format(year,month,day,hr,minute,sec))
Error collecting data for 2024/3/6 6:41:26
```